### PR TITLE
Fix steam price updater callback error

### DIFF
--- a/steam_price_updater/ui/wizard.py
+++ b/steam_price_updater/ui/wizard.py
@@ -49,9 +49,16 @@ class LotWizard:
         except Exception as e:
             logger.warning(f"{LOGGER_PREFIX} Ошибка сохранения состояний мастера: {e}")
     
-    def get_user_key(self, message) -> str:
+    def get_user_key(self, message_or_call) -> str:
         """Генерирует ключ пользователя"""
-        return f"{message.chat.id}_{message.from_user.id}"
+        # Поддерживаем как Message, так и CallbackQuery
+        if hasattr(message_or_call, 'message'):  # CallbackQuery
+            chat_id = message_or_call.message.chat.id
+            user_id = message_or_call.from_user.id
+        else:  # Message
+            chat_id = message_or_call.chat.id
+            user_id = message_or_call.from_user.id
+        return f"{chat_id}_{user_id}"
     
     def start_wizard(self, call: telebot.types.CallbackQuery, bot) -> None:
         """Запускает мастер создания лота"""


### PR DESCRIPTION
Fix `get_user_key` to correctly handle `CallbackQuery` objects, resolving an error when clicking "Add Lot".

---
<a href="https://cursor.com/background-agent?bcId=bc-3f0c2eea-b875-480d-81f1-d737fad1b88e">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-3f0c2eea-b875-480d-81f1-d737fad1b88e">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>